### PR TITLE
Deep extend the options argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function ( options ) {
     return util.inspect( arg, { depth: 3 } );
   };
 
-  var opts = extend( {
+  var opts = extend(true, {
     appendTime: true,
     coloredOutput: false,
     methods: {


### PR DESCRIPTION
Without a deep extend, trying to override just one log method will override everything.